### PR TITLE
Bumped tools versions for CI Pipeline

### DIFF
--- a/.github/workflows/ps-module.yml
+++ b/.github/workflows/ps-module.yml
@@ -28,13 +28,13 @@ jobs:
           fetch-depth: 0
 
       - name: Install GitVersion
-        uses: gittools/actions/gitversion/setup@v0.9.8
+        uses: gittools/actions/gitversion/setup@v0.9.10
         with:
           versionSpec: '5.x'
 
       - name: Determine Version
         id:   gitversion
-        uses: gittools/actions/gitversion/execute@v0.9.8
+        uses: gittools/actions/gitversion/execute@v0.9.10
         with:
           useConfigFile: true
           configFilePath: GitVersion.yml

--- a/tools/build.ps1
+++ b/tools/build.ps1
@@ -50,11 +50,11 @@ $Requirements = @(
     },
     @{
         Name = "Pester"
-        Version = "5.2.1"
+        Version = "5.2.2"
     },
     @{
         Name = "platyPS"
-        Version = "0.14.1"
+        Version = "0.14.2"
     }
 )
 

--- a/tools/build.psake.ps1
+++ b/tools/build.psake.ps1
@@ -1,5 +1,5 @@
 #Requires -Modules @{ModuleName="PSake"; RequiredVersion="4.9.0"},@{ModuleName="PSScriptAnalyzer"; RequiredVersion="1.19.1"},@{ModuleName="BuildHelpers"; RequiredVersion="2.0.16"}
-#Requires -Modules @{ModuleName="Pester"; RequiredVersion="5.2.1"},@{ModuleName="platyPS"; RequiredVersion="0.14.1"}
+#Requires -Modules @{ModuleName="Pester"; RequiredVersion="5.2.2"},@{ModuleName="platyPS"; RequiredVersion="0.14.2"}
 
 Write-Host "Module versions are:"
 Get-Module -Name Psake,PSScriptAnalyzer,BuildHelpers,Pester,platyPS | Select-Object Name,Version


### PR DESCRIPTION
```
Pester 5.2.1 --> 5.2.2
platyPS 0.14.1 --> 0.14.2
GitTools action v0.9.8 --> v0.9.10
```